### PR TITLE
Remove test reporter

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,15 +1,12 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
-  actions: read
   checks: write
   contents: read
 
@@ -45,11 +42,3 @@ jobs:
       - name: Test
         id: test
         run: npm run ci-test
-
-      - name: Report Tests
-        id: report
-        uses: dorny/test-reporter@v1
-        with:
-          name: Test Report
-          path: reports/jest-*.xml
-          reporter: jest-junit


### PR DESCRIPTION
Since this is causing forked PRs to fail, the `dorny/test-reporter` is not providing much value at the moment.

Closes #48 